### PR TITLE
Revert "build(deps): bump actions/setup-python from 2.2.2 to 2.3.1"

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           brew install tree
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
-      - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+      - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Bootstrap clingo
@@ -175,7 +175,7 @@ jobs:
         python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
-      - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+      - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup repo and non-root user

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: 3.9
     - name: spack install
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 700
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: 3.9
     - name: spack install
@@ -53,7 +53,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: 3.9
     - name: spack install

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: 3.9
     - name: Install Python Packages
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: 3.9
     - name: Install Python packages
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install System packages
@@ -163,7 +163,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: 3.9
     - name: Install System packages
@@ -229,7 +229,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: 3.9
     - name: Install System packages
@@ -278,7 +278,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python packages


### PR DESCRIPTION
To keep in sync with Spack.